### PR TITLE
Read curl headers from a file

### DIFF
--- a/bin/auth
+++ b/bin/auth
@@ -14,8 +14,10 @@ if [ -z "${LONGBOAT_TOKEN}" ]; then
     echo "==> Writing user config ${USERCONFIG}"
     if [ ! -d "${USERCONFIGDIR}" ]; then
       mkdir ${USERCONFIGDIR}
+      chmod 700 ${USERCONFIGDIR}
     fi
     echo "# Longboat API Configuration" > ${USERCONFIG}
+    chmod 600 ${USERCONFIG}
     echo "LONGBOAT_TOKEN=\"${TOKEN}\"" >> ${USERCONFIG}
     echo "LONGBOAT_PATH=\"${BOATDIR}\"" >> ${USERCONFIG}
     echo "==> Done. Test it with: boat doctor"
@@ -32,4 +34,3 @@ echo "content of LONGBOAT_TOKEN in ${USERCONFIG}"
 echo "or delete the file ${USERCONFIG} and afterwards run: boat auth"
 
 exit 1
-

--- a/bin/doctor
+++ b/bin/doctor
@@ -37,6 +37,15 @@ headline "Software Requirements"
 command -v curl > /dev/null
 if [ $? -eq 0 ]; then
   ok "curl is installed"
+
+  # Check curl version
+  CURL_VERSION=`curl --version | head -1 | awk '{print $2}'`
+  if version_gt ${CURL_VERSION} 7.55.0; then
+    ok "curl v7.55.0 or greater (found v${CURL_VERSION})"
+  else
+    error "curl v7.55.0 or greater is required, but found v${CURL_VERSION}"
+    space "Read more in FIXME: Link to docs"
+  fi
 else
   error "curl command not found!"
   space "Read more on FIXME: Link to docs"

--- a/bin/pull
+++ b/bin/pull
@@ -3,6 +3,7 @@
 CURL_SILENT=true
 
 echo "==> Updating users hosts file ~/.longboat/hosts..."
+user_dir_perms
 user_hosts_update
 
 if [ -z "${LONGBOAT_PROJECT}" ]; then

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -8,7 +8,14 @@ function api_curl() {
   local ARGS=""
   local METHOD="$1"
   local URL="${LONGBOAT_ENDPOINT}/${LONGBOAT_API}$2"
+  local CURL_HEADER="${USERCONFIGDIR}/curl_header"
 
+  # Create header file for CURL requests and keep it secret
+  touch ${CURL_HEADER}
+  chmod 600 ${CURL_HEADER}
+  echo "Authorization: ${LONGBOAT_TOKEN}" > ${CURL_HEADER}
+
+  # Create arguments for CURL request
   if [ $# -gt 2 ]; then
     for ARG in "${@:3}"; do
       ARGS="${ARGS} --data-urlencode ${ARG}"
@@ -18,7 +25,7 @@ function api_curl() {
   CURL_TMP="/tmp/longboat.curl.$$"
   touch ${CURL_TMP}
   chmod 600 ${CURL_TMP}
-  CURL_CODE=`curl -s -w "%{http_code}" -o "${CURL_TMP}" -H "Authorization: ${LONGBOAT_TOKEN}" ${ARGS} -X ${METHOD} "${URL}"`
+  CURL_CODE=`curl -s -w "%{http_code}" -o "${CURL_TMP}" --header "@${CURL_HEADER}" ${ARGS} -X ${METHOD} "${URL}"`
   CURL_EXIT="$?"
   CURL_RESPONSE=`cat ${CURL_TMP}`
   rm ${CURL_TMP}
@@ -58,8 +65,18 @@ function confirm_delete() {
   fi
 }
 
+function version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1";
+}
+
+function user_dir_perms() {
+  chmod 700 ${USERCONFIGDIR}
+  chmod 600 ${USERCONFIG} ${USERHOSTS}
+}
+
 function user_hosts_update() {
   CURL_SILENT=true
   api_curl GET /user/config/hosts
   echo "${CURL_RESPONSE}" > ${USERHOSTS}
+  chmod 600 ${USERHOSTS}
 }


### PR DESCRIPTION
We don't want to leak ie. LONGBOAT_TOKEN into ie. ps
Unfortunately, reading headers from a file was first introduced in
curl v7.55.0 - August 9 2017 .. :/

Also added a check in `boat doctor` to test for minimum curl version.