### PR TITLE
API auth requires Bearer in the Authentication header

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -24,9 +24,7 @@ if [ "${CURL_CODE}" == "200" ]; then
     exit 1
   fi
 
-  #FIXME: Support for having a project in a custom git repository
-
-  echo "==> Cloning project into ${PROJECTDIR} directory..."
+  echo "==> Creating project in ${PROJECTDIR} directory..."
   mkdir ./${PROJECTDIR}
   cd ./${PROJECTDIR}
 

--- a/lib/subroutines
+++ b/lib/subroutines
@@ -13,7 +13,7 @@ function api_curl() {
   # Create header file for CURL requests and keep it secret
   touch ${CURL_HEADER}
   chmod 600 ${CURL_HEADER}
-  echo "Authorization: ${LONGBOAT_TOKEN}" > ${CURL_HEADER}
+  echo "Authorization: Bearer ${LONGBOAT_TOKEN}" > ${CURL_HEADER}
 
   # Create arguments for CURL request
   if [ $# -gt 2 ]; then


### PR DESCRIPTION
API Authentication was changed a little bit, to include Bearer in the authentication header.

Changes have already been deployed to production API.