### PR TITLE
Keep roles out of git repository

### DIFF
--- a/files/gitignore
+++ b/files/gitignore
@@ -1,4 +1,4 @@
 # Default .gitignore file for Longboat project
 # FIXME: See docs for more information
-roles/longboat
+roles/
 


### PR DESCRIPTION
All roles should be kept out of the Longboat project git repository.